### PR TITLE
Autosave

### DIFF
--- a/lorien/Config.gd
+++ b/lorien/Config.gd
@@ -24,4 +24,4 @@ const DEFAULT_UI_SCALE_MODE 		:= Types.UIScale.AUTO
 const DEFAULT_UI_SCALE  			:= 1.0
 const DEFAULT_GRID_PATTERN 			:= Types.GridPattern.DOTS
 const DEFAULT_GRID_SIZE 			:= 25.0
-
+const DEFAULT_AUTOSAVE_ENABLED		:= false

--- a/lorien/Config.gd
+++ b/lorien/Config.gd
@@ -2,7 +2,7 @@ class_name Config
 
 const VERSION_MAJOR					:= 0
 const VERSION_MINOR					:= 6
-const VERSION_PATCH					:= 0
+const VERSION_PATCH					:= 1
 const VERSION_STATUS				:= ""
 const VERSION_STRING				:= "%d.%d.%d%s" % [VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, VERSION_STATUS]
 const CONFIG_PATH 					:= "user://settings.cfg"

--- a/lorien/Config.gd
+++ b/lorien/Config.gd
@@ -25,3 +25,4 @@ const DEFAULT_UI_SCALE  			:= 1.0
 const DEFAULT_GRID_PATTERN 			:= Types.GridPattern.DOTS
 const DEFAULT_GRID_SIZE 			:= 25.0
 const DEFAULT_AUTOSAVE_ENABLED		:= false
+const DEFAULT_AUTOSAVE_PERIOD		:= 30

--- a/lorien/Main.gd
+++ b/lorien/Main.gd
@@ -74,6 +74,7 @@ func _ready():
 	_settings_dialog.connect("grid_pattern_changed", self, "_on_grid_pattern_changed")
 	_settings_dialog.connect("canvas_color_changed", self, "_on_canvas_color_changed")
 	_settings_dialog.connect("autosave_enabled_changed", self, "_on_autosave_enabled_changed")
+	_settings_dialog.connect("autosave_period_changed", self, "_on_autosave_period_changed")
 
 	self.add_child(_autosave_timer)
 	_autosave_timer.connect("timeout", self, "_autosave_project")
@@ -353,9 +354,13 @@ func _on_canvas_color_changed(color: Color) -> void:
 # -------------------------------------------------------------------------------------------------
 func _on_autosave_enabled_changed(enabled: bool) -> void:
 	if enabled:
-		_autosave_timer.start(15)
+		_autosave_timer.start(Settings.get_value(Settings.AUTOSAVE_PERIOD, Config.DEFAULT_AUTOSAVE_PERIOD))
 	else:
 		_autosave_timer.stop()
+
+# -------------------------------------------------------------------------------------------------
+func _on_autosave_period_changed(period: float) -> void:
+	_autosave_timer.wait_time = period
 
 # -------------------------------------------------------------------------------------------------
 func _on_clear_canvas() -> void:

--- a/lorien/Main.gd
+++ b/lorien/Main.gd
@@ -23,6 +23,7 @@ onready var _edit_palette_dialog: EditPaletteDialog = $EditPaletteDialog
 
 var _ui_visible := true 
 var _player_enabled := false
+var _autosave_timer := Timer.new()
 
 # -------------------------------------------------------------------------------------------------
 func _ready():
@@ -72,7 +73,12 @@ func _ready():
 	_settings_dialog.connect("grid_size_changed", self, "_on_grid_size_changed")
 	_settings_dialog.connect("grid_pattern_changed", self, "_on_grid_pattern_changed")
 	_settings_dialog.connect("canvas_color_changed", self, "_on_canvas_color_changed")
-	
+	_settings_dialog.connect("autosave_enabled_changed", self, "_on_autosave_enabled_changed")
+
+	self.add_child(_autosave_timer)
+	_autosave_timer.connect("timeout", self, "_autosave_project")
+	_on_autosave_enabled_changed(Settings.get_value(Settings.AUTOSAVE_ENABLED, Config.DEFAULT_AUTOSAVE_ENABLED))
+
 	# Initialize scale
 	_on_scale_changed()
 	
@@ -86,12 +92,6 @@ func _ready():
 	
 	# Apply state from previous session
 	_apply_state()
-
-	var autosave_timer := Timer.new()
-	autosave_timer.autostart = true
-	autosave_timer.wait_time = 15
-	autosave_timer.connect("timeout", self, "_autosave_project")
-	self.add_child(autosave_timer)
 
 # -------------------------------------------------------------------------------------------------
 func _notification(what):
@@ -349,6 +349,13 @@ func _on_grid_pattern_changed(pattern: int) -> void:
 func _on_canvas_color_changed(color: Color) -> void:
 	_canvas.set_background_color(color)
 	_canvas_grid.set_canvas_color(color)
+
+# -------------------------------------------------------------------------------------------------
+func _on_autosave_enabled_changed(enabled: bool) -> void:
+	if enabled:
+		_autosave_timer.start(15)
+	else:
+		_autosave_timer.stop()
 
 # -------------------------------------------------------------------------------------------------
 func _on_clear_canvas() -> void:

--- a/lorien/Main.gd
+++ b/lorien/Main.gd
@@ -86,6 +86,12 @@ func _ready():
 	# Apply state from previous session
 	_apply_state()
 
+	var autosave_timer := Timer.new()
+	autosave_timer.autostart = true
+	autosave_timer.wait_time = 15
+	autosave_timer.connect("timeout", self, "_autosave_project")
+	self.add_child(autosave_timer)
+
 # -------------------------------------------------------------------------------------------------
 func _notification(what):
 	if NOTIFICATION_WM_QUIT_REQUEST == what:
@@ -268,6 +274,10 @@ func _save_project(project: Project) -> void:
 	project.meta_data = meta_data
 	ProjectManager.save_project(project)
 	_menubar.update_tab_title(project)
+
+# -------------------------------------------------------------------------------------------------
+func _autosave_project() -> void:
+	ProjectManager.autosave_active_project()
 
 # -------------------------------------------------------------------------------------------------
 func _on_create_new_project() -> void:

--- a/lorien/Main.gd
+++ b/lorien/Main.gd
@@ -7,6 +7,7 @@ onready var _statusbar: Statusbar = $Statusbar
 onready var _menubar: Menubar = $Topbar/Menubar
 onready var _toolbar: Toolbar = $Topbar/Toolbar
 onready var _file_dialog: FileDialog = $FileDialog
+onready var _restore_autosave_dialog: ConfirmationDialog = $RestoreAutosaveDialog
 onready var _export_dialog : FileDialog = $ExportDialog
 onready var _about_dialog: WindowDialog = $AboutDialog
 onready var _settings_dialog: WindowDialog = $SettingsDialog
@@ -377,9 +378,20 @@ func _on_open_project(filepath: String) -> bool:
 	# Create and open it
 	project = ProjectManager.add_project(filepath)
 	_make_project_active(project)
+
+	# Check for autosave data and ask the user if they want to load it
+	file = File.new()
+	if file.file_exists(project.get_autosave_filepath()):
+		_restore_autosave_dialog.connect("confirmed", self, "_on_confirm_restore_autosave", [project])
+		_restore_autosave_dialog.popup_centered()
 	
 	return true
-	
+
+# -------------------------------------------------------------------------------------------------
+func _on_confirm_restore_autosave(project: Project) -> void:
+	ProjectManager.load_project_autosave(project)
+	_canvas.use_project(project)
+
 # -------------------------------------------------------------------------------------------------
 func _on_save_project_as() -> void:
 	var active_project: Project = ProjectManager.get_active_project()

--- a/lorien/Main.tscn
+++ b/lorien/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=17 format=2]
+[gd_scene load_steps=18 format=2]
 
 [ext_resource path="res://Main.gd" type="Script" id=1]
 [ext_resource path="res://InfiniteCanvas/InfiniteCanvas.tscn" type="PackedScene" id=2]
@@ -15,6 +15,7 @@
 [ext_resource path="res://UI/ColorPalettePicker.tscn" type="PackedScene" id=13]
 [ext_resource path="res://UI/Dialogs/EditPaletteDialog.tscn" type="PackedScene" id=14]
 [ext_resource path="res://UI/Dialogs/DeletePaletteDialog.tscn" type="PackedScene" id=15]
+[ext_resource path="res://UI/Dialogs/RestoreAutosaveDialog.tscn" type="PackedScene" id=16]
 
 [sub_resource type="StyleBoxFlat" id=1]
 bg_color = Color( 0.207843, 0.211765, 0.227451, 1 )
@@ -168,6 +169,13 @@ margin_left = -150.0
 margin_top = -50.0
 margin_right = 150.0
 margin_bottom = 50.0
+
+[node name="RestoreAutosaveDialog" parent="." instance=ExtResource( 16 )]
+visible = false
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
 
 [node name="EditPaletteDialog" parent="." instance=ExtResource( 14 )]
 anchor_left = 0.5

--- a/lorien/Misc/Settings.gd
+++ b/lorien/Misc/Settings.gd
@@ -18,6 +18,7 @@ const RENDERING_FOREGROUND_FPS			:= "rendering_foreground_fps"
 const RENDERING_BACKGROUND_FPS			:= "rendering_background_fps"
 const RENDERING_BRUSH_ROUNDING			:= "rendering_brush_rounding"
 const COLOR_PALETTE_UUID_LAST_USED		:= "color_palette_uuid_last_used"
+const AUTOSAVE_ENABLED					:= "autosave_enabled"
 
 # -------------------------------------------------------------------------------------------------
 var _config_file := ConfigFile.new()

--- a/lorien/Misc/Settings.gd
+++ b/lorien/Misc/Settings.gd
@@ -19,6 +19,7 @@ const RENDERING_BACKGROUND_FPS			:= "rendering_background_fps"
 const RENDERING_BRUSH_ROUNDING			:= "rendering_brush_rounding"
 const COLOR_PALETTE_UUID_LAST_USED		:= "color_palette_uuid_last_used"
 const AUTOSAVE_ENABLED					:= "autosave_enabled"
+const AUTOSAVE_PERIOD					:= "autosave_period"
 
 # -------------------------------------------------------------------------------------------------
 var _config_file := ConfigFile.new()

--- a/lorien/ProjectManager/Project.gd
+++ b/lorien/ProjectManager/Project.gd
@@ -44,5 +44,9 @@ func get_filename() -> String:
 	return filepath.get_file()
 
 # -------------------------------------------------------------------------------------------------
+func get_autosave_filepath() -> String:
+	return "%s.autosave" % filepath
+
+# -------------------------------------------------------------------------------------------------
 func _to_string() -> String:
 	return "%s: id: %d, loaded: %s, dirty: %s" % [filepath, id, loaded, dirty]

--- a/lorien/ProjectManager/ProjectManager.gd
+++ b/lorien/ProjectManager/ProjectManager.gd
@@ -64,12 +64,23 @@ func save_all_projects() -> void:
 			save_project(p)
 
 # -------------------------------------------------------------------------------------------------
+func autosave_active_project() -> void:
+	if !_active_project.filepath.empty() && _active_project.loaded && _active_project.dirty:
+			Serializer.autosave_project(_active_project)
+
+# -------------------------------------------------------------------------------------------------
 func _load_project(project: Project) -> void:
 	if !project.loaded:
 		Serializer.load_project(project)
 		project.loaded = true
 	else:
 		print_debug("Trying to load already loaded project")
+
+# -------------------------------------------------------------------------------------------------
+func load_project_autosave(project: Project) -> void:
+	Serializer.load_project_autosave(project)
+	project.loaded = true
+	project.dirty = true
 
 # -------------------------------------------------------------------------------------------------
 func get_open_project_by_filepath(filepath: String) -> Project:

--- a/lorien/ProjectManager/Serializer.gd
+++ b/lorien/ProjectManager/Serializer.gd
@@ -14,16 +14,16 @@ const TYPE_BRUSH_STROKE := 0
 const TYPE_ERASER_STROKE_DEPRECATED := 1 # Deprecated since v0; will be ignored when read; structually the same as normal brush stroke
 
 # -------------------------------------------------------------------------------------------------
-static func save_project(project: Project) -> void:
+static func _save_project_to_file(project: Project, filepath: String) -> void:
 	var start_time := OS.get_ticks_msec()
 	
 	# Open file
 	var file := File.new()
-	var err = file.open_compressed(project.filepath, File.WRITE, COMPRESSION_METHOD)
+	var err = file.open_compressed(filepath, File.WRITE, COMPRESSION_METHOD)
 	if err != OK:
-		print_debug("Failed to open file for writing: %s" % project.filepath)
+		print_debug("Failed to open file for writing: %s" % filepath)
 		return
-	
+
 	# Meta data
 	file.store_32(VERSION_NUMBER)
 	file.store_pascal_string(_dict_to_metadata_str(project.meta_data))
@@ -55,17 +55,32 @@ static func save_project(project: Project) -> void:
 
 	# Done
 	file.close()
-	print("Saved %s in %d ms" % [project.filepath, (OS.get_ticks_msec() - start_time)])
+	print("Saved %s in %d ms" % [filepath, (OS.get_ticks_msec() - start_time)])
 
 # -------------------------------------------------------------------------------------------------
-static func load_project(project: Project) -> void:
+static func save_project(project: Project) -> void:
+	_save_project_to_file(project, project.filepath)
+
+	# Cleanup autosave
+	var file := File.new()
+	if file.file_exists(project.get_autosave_filepath()):
+		print("Deleted autosave %s" % [project.get_autosave_filepath()])
+		OS.move_to_trash(project.get_autosave_filepath())
+
+# -------------------------------------------------------------------------------------------------
+static func autosave_project(project: Project) -> void:
+	if !project.filepath.empty():
+		_save_project_to_file(project, project.get_autosave_filepath())
+
+# -------------------------------------------------------------------------------------------------
+static func _load_project_from_file(project: Project, filepath: String) -> void:
 	var start_time := OS.get_ticks_msec()
 
 	# Open file
 	var file := File.new()
-	var err = file.open_compressed(project.filepath, File.READ, COMPRESSION_METHOD)
+	var err = file.open_compressed(filepath, File.READ, COMPRESSION_METHOD)
 	if err != OK:
-		print_debug("Failed to load file: %s" % project.filepath)
+		print_debug("Failed to load file: %s" % filepath)
 		return
 	
 	# Clear potential previous data
@@ -119,7 +134,15 @@ static func load_project(project: Project) -> void:
 	
 	# Done
 	file.close()
-	print("Loaded %s in %d ms" % [project.filepath, (OS.get_ticks_msec() - start_time)])
+	print("Loaded %s in %d ms" % [filepath, (OS.get_ticks_msec() - start_time)])
+
+# -------------------------------------------------------------------------------------------------
+static func load_project(project: Project) -> void:
+	_load_project_from_file(project, project.filepath)
+
+# -------------------------------------------------------------------------------------------------
+static func load_project_autosave(project: Project) -> void:
+	_load_project_from_file(project, project.get_autosave_filepath())
 
 # -------------------------------------------------------------------------------------------------
 static func _dict_to_metadata_str(d: Dictionary) -> String:

--- a/lorien/UI/Dialogs/RestoreAutosaveDialog.gd
+++ b/lorien/UI/Dialogs/RestoreAutosaveDialog.gd
@@ -1,0 +1,2 @@
+extends ConfirmationDialog
+

--- a/lorien/UI/Dialogs/RestoreAutosaveDialog.tscn
+++ b/lorien/UI/Dialogs/RestoreAutosaveDialog.tscn
@@ -1,0 +1,18 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://UI/Themes/theme_dark.tres" type="Theme" id=1]
+[ext_resource path="res://UI/Dialogs/RestoreAutosaveDialog.gd" type="Script" id=2]
+[ext_resource path="res://Assets/icon.png" type="Texture" id=3]
+
+[sub_resource type="StyleBoxEmpty" id=1]
+
+[node name="RestoreAutosaveDialog" type="ConfirmationDialog"]
+visible = true
+theme = ExtResource( 1 )
+popup_exclusive = true
+window_title = "Restore Autosave"
+dialog_text = "This file has autosave data!\nWould you like to restore it?"
+script = ExtResource( 2 )
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/lorien/UI/Dialogs/SettingsDialog.gd
+++ b/lorien/UI/Dialogs/SettingsDialog.gd
@@ -21,6 +21,7 @@ signal canvas_color_changed(color)
 signal grid_size_changed(size)
 signal grid_pattern_changed(pattern)
 signal autosave_enabled_changed(enabled)
+signal autosave_period_changed(period)
 
 # -------------------------------------------------------------------------------------------------
 onready var _tab_container: TabContainer = $MarginContainer/TabContainer
@@ -45,6 +46,7 @@ onready var _ui_scale: SpinBox = $MarginContainer/TabContainer/Appearance/VBoxCo
 onready var _grid_size: SpinBox = $MarginContainer/TabContainer/Appearance/VBoxContainer/GridSize/GridSize
 onready var _grid_pattern: OptionButton = $MarginContainer/TabContainer/Appearance/VBoxContainer/GridPattern/GridPattern
 onready var _autosave_enabled: CheckButton = $MarginContainer/TabContainer/General/VBoxContainer/AutosaveEnabled/CheckButton
+onready var _autosave_period: SpinBox = $MarginContainer/TabContainer/General/VBoxContainer/AutosavePeriod/AutosavePeriod
 
 # -------------------------------------------------------------------------------------------------
 func _ready():
@@ -75,6 +77,7 @@ func _set_values() -> void:
 	var grid_pattern = Settings.get_value(Settings.APPEARANCE_GRID_PATTERN, Config.DEFAULT_GRID_PATTERN)
 	var grid_size = Settings.get_value(Settings.APPEARANCE_GRID_SIZE, Config.DEFAULT_GRID_SIZE)
 	var autosave_enabled = Settings.get_value(Settings.AUTOSAVE_ENABLED, Config.DEFAULT_AUTOSAVE_ENABLED)
+	var autosave_period = Settings.get_value(Settings.AUTOSAVE_PERIOD, Config.DEFAULT_AUTOSAVE_PERIOD)
 	
 	match theme:
 		Types.UITheme.DARK: _theme.selected = THEME_DARK_INDEX
@@ -106,6 +109,7 @@ func _set_values() -> void:
 	_background_fps.value = background_fps
 	_ui_scale.value = ui_scale
 	_autosave_enabled.pressed = autosave_enabled
+	_autosave_period.value = autosave_period
 
 # -------------------------------------------------------------------------------------------------
 func _set_rounding():
@@ -259,3 +263,9 @@ func _on_UIScale_value_changed(value: float):
 func _on_CheckButton_toggled(button_pressed: bool):
 	Settings.set_value(Settings.AUTOSAVE_ENABLED, button_pressed)
 	emit_signal("autosave_enabled_changed", button_pressed)
+
+# -------------------------------------------------------------------------------------------------
+func _on_AutosavePeriod_value_changed(period: float):
+	if Input.is_action_just_pressed("ui_accept") || _ui_scale.is_ready():
+		Settings.set_value(Settings.AUTOSAVE_PERIOD, period)
+		emit_signal("autosave_period_changed", period)

--- a/lorien/UI/Dialogs/SettingsDialog.gd
+++ b/lorien/UI/Dialogs/SettingsDialog.gd
@@ -20,6 +20,7 @@ signal ui_scale_changed
 signal canvas_color_changed(color)
 signal grid_size_changed(size)
 signal grid_pattern_changed(pattern)
+signal autosave_enabled_changed(enabled)
 
 # -------------------------------------------------------------------------------------------------
 onready var _tab_container: TabContainer = $MarginContainer/TabContainer
@@ -43,6 +44,7 @@ onready var _ui_scale_options: OptionButton = $MarginContainer/TabContainer/Appe
 onready var _ui_scale: SpinBox = $MarginContainer/TabContainer/Appearance/VBoxContainer/UIScale/HBoxContainer/UIScale
 onready var _grid_size: SpinBox = $MarginContainer/TabContainer/Appearance/VBoxContainer/GridSize/GridSize
 onready var _grid_pattern: OptionButton = $MarginContainer/TabContainer/Appearance/VBoxContainer/GridPattern/GridPattern
+onready var _autosave_enabled: CheckButton = $MarginContainer/TabContainer/General/VBoxContainer/AutosaveEnabled/CheckButton
 
 # -------------------------------------------------------------------------------------------------
 func _ready():
@@ -72,6 +74,7 @@ func _set_values() -> void:
 	var ui_scale = Settings.get_value(Settings.APPEARANCE_UI_SCALE, Config.DEFAULT_UI_SCALE)
 	var grid_pattern = Settings.get_value(Settings.APPEARANCE_GRID_PATTERN, Config.DEFAULT_GRID_PATTERN)
 	var grid_size = Settings.get_value(Settings.APPEARANCE_GRID_SIZE, Config.DEFAULT_GRID_SIZE)
+	var autosave_enabled = Settings.get_value(Settings.AUTOSAVE_ENABLED, Config.DEFAULT_AUTOSAVE_ENABLED)
 	
 	match theme:
 		Types.UITheme.DARK: _theme.selected = THEME_DARK_INDEX
@@ -102,6 +105,7 @@ func _set_values() -> void:
 	_foreground_fps.value = foreground_fps
 	_background_fps.value = background_fps
 	_ui_scale.value = ui_scale
+	_autosave_enabled.pressed = autosave_enabled
 
 # -------------------------------------------------------------------------------------------------
 func _set_rounding():
@@ -250,3 +254,8 @@ func _on_UIScale_value_changed(value: float):
 		Settings.set_value(Settings.APPEARANCE_UI_SCALE, value)
 		emit_signal("ui_scale_changed")
 		popup_centered()
+
+# -------------------------------------------------------------------------------------------------
+func _on_CheckButton_toggled(button_pressed: bool):
+	Settings.set_value(Settings.AUTOSAVE_ENABLED, button_pressed)
+	emit_signal("autosave_enabled_changed", button_pressed)

--- a/lorien/UI/Dialogs/SettingsDialog.tscn
+++ b/lorien/UI/Dialogs/SettingsDialog.tscn
@@ -180,10 +180,31 @@ margin_right = 496.0
 margin_bottom = 25.0
 size_flags_horizontal = 3
 
-[node name="HSeparator" type="HSeparator" parent="MarginContainer/TabContainer/General/VBoxContainer"]
+[node name="AutosavePeriod" type="HBoxContainer" parent="MarginContainer/TabContainer/General/VBoxContainer"]
 margin_top = 177.0
 margin_right = 496.0
-margin_bottom = 189.0
+margin_bottom = 198.0
+size_flags_horizontal = 3
+
+[node name="Label" type="Label" parent="MarginContainer/TabContainer/General/VBoxContainer/AutosavePeriod"]
+margin_top = 2.0
+margin_right = 246.0
+margin_bottom = 19.0
+size_flags_horizontal = 3
+size_flags_vertical = 6
+text = "SETTINGS_AUTOSAVE_PERIOD"
+
+[node name="AutosavePeriod" type="SpinBox" parent="MarginContainer/TabContainer/General/VBoxContainer/AutosavePeriod"]
+margin_left = 250.0
+margin_right = 496.0
+margin_bottom = 21.0
+size_flags_horizontal = 3
+value = 30.0
+
+[node name="HSeparator" type="HSeparator" parent="MarginContainer/TabContainer/General/VBoxContainer"]
+margin_top = 202.0
+margin_right = 496.0
+margin_bottom = 214.0
 custom_constants/separation = 12
 custom_styles/separator = SubResource( 3 )
 
@@ -530,6 +551,7 @@ dialog_autowrap = true
 [connection signal="text_changed" from="MarginContainer/TabContainer/General/VBoxContainer/DefaultSaveDir/DefaultSaveDir" to="." method="_on_DefaultSaveDir_text_changed"]
 [connection signal="item_selected" from="MarginContainer/TabContainer/General/VBoxContainer/Language/OptionButton" to="." method="_on_OptionButton_item_selected"]
 [connection signal="toggled" from="MarginContainer/TabContainer/General/VBoxContainer/AutosaveEnabled/CheckButton" to="." method="_on_CheckButton_toggled"]
+[connection signal="value_changed" from="MarginContainer/TabContainer/General/VBoxContainer/AutosavePeriod/AutosavePeriod" to="." method="_on_AutosavePeriod_value_changed"]
 [connection signal="item_selected" from="MarginContainer/TabContainer/Appearance/VBoxContainer/Theme/Theme" to="." method="_on_Theme_item_selected"]
 [connection signal="item_selected" from="MarginContainer/TabContainer/Appearance/VBoxContainer/UIScale/HBoxContainer/UIScaleOptions" to="." method="_on_UIScaleOptions_item_selected"]
 [connection signal="gui_input" from="MarginContainer/TabContainer/Appearance/VBoxContainer/UIScale/HBoxContainer/UIScale" to="MarginContainer/TabContainer/Appearance/VBoxContainer/UIScale/HBoxContainer/UIScale" method="_on_UIScale_gui_input"]

--- a/lorien/UI/Dialogs/SettingsDialog.tscn
+++ b/lorien/UI/Dialogs/SettingsDialog.tscn
@@ -160,10 +160,30 @@ margin_bottom = 25.0
 size_flags_horizontal = 3
 text = "English"
 
-[node name="HSeparator" type="HSeparator" parent="MarginContainer/TabContainer/General/VBoxContainer"]
+[node name="AutosaveEnabled" type="HBoxContainer" parent="MarginContainer/TabContainer/General/VBoxContainer"]
 margin_top = 148.0
 margin_right = 496.0
-margin_bottom = 160.0
+margin_bottom = 173.0
+size_flags_horizontal = 3
+
+[node name="Label" type="Label" parent="MarginContainer/TabContainer/General/VBoxContainer/AutosaveEnabled"]
+margin_top = 4.0
+margin_right = 246.0
+margin_bottom = 21.0
+size_flags_horizontal = 3
+size_flags_vertical = 6
+text = "SETTINGS_AUTOSAVE_ENABLED"
+
+[node name="CheckButton" type="CheckButton" parent="MarginContainer/TabContainer/General/VBoxContainer/AutosaveEnabled"]
+margin_left = 250.0
+margin_right = 496.0
+margin_bottom = 25.0
+size_flags_horizontal = 3
+
+[node name="HSeparator" type="HSeparator" parent="MarginContainer/TabContainer/General/VBoxContainer"]
+margin_top = 177.0
+margin_right = 496.0
+margin_bottom = 189.0
 custom_constants/separation = 12
 custom_styles/separator = SubResource( 3 )
 
@@ -509,6 +529,7 @@ dialog_autowrap = true
 [connection signal="value_changed" from="MarginContainer/TabContainer/General/VBoxContainer/DefaultBrushSize/DefaultBrushSize" to="." method="_on_DefaultBrushSize_value_changed"]
 [connection signal="text_changed" from="MarginContainer/TabContainer/General/VBoxContainer/DefaultSaveDir/DefaultSaveDir" to="." method="_on_DefaultSaveDir_text_changed"]
 [connection signal="item_selected" from="MarginContainer/TabContainer/General/VBoxContainer/Language/OptionButton" to="." method="_on_OptionButton_item_selected"]
+[connection signal="toggled" from="MarginContainer/TabContainer/General/VBoxContainer/AutosaveEnabled/CheckButton" to="." method="_on_CheckButton_toggled"]
 [connection signal="item_selected" from="MarginContainer/TabContainer/Appearance/VBoxContainer/Theme/Theme" to="." method="_on_Theme_item_selected"]
 [connection signal="item_selected" from="MarginContainer/TabContainer/Appearance/VBoxContainer/UIScale/HBoxContainer/UIScaleOptions" to="." method="_on_UIScaleOptions_item_selected"]
 [connection signal="gui_input" from="MarginContainer/TabContainer/Appearance/VBoxContainer/UIScale/HBoxContainer/UIScale" to="MarginContainer/TabContainer/Appearance/VBoxContainer/UIScale/HBoxContainer/UIScale" method="_on_UIScale_gui_input"]


### PR DESCRIPTION
This PR adds autosave functionality to v0.6.0 to prevent accidental loss of data (bumping the version to v0.6.1).

* _Only_ files that have already been saved will have autosaves
  * This avoids any issues with where to save files (laziest choice for now) instead appending `.autosave` to the project's filename 
* _Only_ the active project will be autosaved
  * This avoids doing work for projects that are less likely to be changed. It'd be neat to connect autosave to tab switching to reduce potential loss further
* Autosave is **opt-in**
  * Didn't want to make a disruptive change 
* The autosave period is configurable
